### PR TITLE
Sqlserver/powershell

### DIFF
--- a/sqlserver/content-layer/Build-ContentLayer.ps1
+++ b/sqlserver/content-layer/Build-ContentLayer.ps1
@@ -342,7 +342,7 @@ $config = New-Object -TypeName PsObject -Property (@{
     'SqlFile' = (Get-Item $SqlFile | % { $_.FullName });
     'DatabaseDir'= (Get-Item $DatabaseDir | % { $_.FullName });
     'ConfirmRun' = (Get-Decision $ConfirmRun $DeclineRun);
-    'ConfirmPush' = (Get-Decision $ConfirmPush $DeclinePush) -or $RemoteImage;
+    'ConfirmPush' = (Get-Decision $ConfirmPush $DeclinePush);
     'RemoteImage' = $RemoteImage;
 })
 

--- a/sqlserver/content-layer/Build-ContentLayer.ps1
+++ b/sqlserver/content-layer/Build-ContentLayer.ps1
@@ -59,7 +59,7 @@ Decline to push the content layer image.
 
 .EXAMPLE
 
-.\content_layer.ps1
+.\Build-ContentLayer.ps1
 
 
 Build an image with content layer in fully interactive mode. PowerShell script will ask to specify each required parameter. After successful build script will stop and ask for permissions to execute a test run and push the image.
@@ -67,7 +67,7 @@ Build an image with content layer in fully interactive mode. PowerShell script w
 
 .EXAMPLE 
 
-.\content_layer.ps1 -SqlFile '..\samples\WildcardSearches\Wildcard Searches.sql' -DatabaseDir '..\samples\WildcardSearches\DATA' -OutputImage 'demo-content' -DeclineRun -ConfirmPush -RemoteImage 'sqlservercentral/wildcard-searches'
+.\Build-ContentLayer.ps1 -SqlFile '..\samples\WildcardSearches\Wildcard Searches.sql' -DatabaseDir '..\samples\WildcardSearches\DATA' -OutputImage 'demo-content' -DeclineRun -ConfirmPush -RemoteImage 'sqlservercentral/wildcard-searches'
 
 Build a content layer image using 'Wildcard Searches.sql' script a sample database saved in 'DATA' directory. The output image will be saved in the local repository as 'demo-content'. After successful build PowerShell script will skip a test run and push the image to the Turbo Hub to 'wildcard-searches' repo in 'sqlservercentral' organization.
 

--- a/sqlserver/content-layer/build.me
+++ b/sqlserver/content-layer/build.me
@@ -4,16 +4,16 @@
 # This TurboScript creates a SQL Lab Suite content image.
 
 # Image meta
-meta namespace="sqldemo"
-meta name="article"
-meta tag="1.0.test"
+# meta namespace="sqldemo"
+# meta name="article"
+# meta tag="1.0.test"
 
 # Article meta
-meta title="Article Name"
-meta description="Short description"
-meta publisher="Author"
-meta website="Link to the article"
-meta version="1.0.dateiso"
+# meta title="Article Name"
+# meta description="Short description"
+# meta publisher="Author"
+# meta website="Link to the article"
+# meta version="1.0.dateiso"
 
 # Script
 var script = 1

--- a/sqlserver/content-layer/content_layer.ps1
+++ b/sqlserver/content-layer/content_layer.ps1
@@ -1,0 +1,83 @@
+﻿[CmdletBinding()]
+param
+(
+	[Parameter(Mandatory=$True,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,HelpMessage="Name of the output image")]
+	[string] $OutputImage,
+	[Parameter(Mandatory=$True,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,HelpMessage="Path to the SQL script")]
+	[string] $SqlFile,
+    [Parameter(Mandatory=$True,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,HelpMessage="Path to the database directory")]
+    [string] $DatabaseDir
+)
+
+function PrintFatal($errorMsg)
+{
+    Write-Host $errorMsg -ForegroundColor Red
+}
+
+function Build($config)
+{
+    $initialLocation = $pwd.Path
+    Try
+    {
+        $tempDirName = [System.Guid]::NewGuid().ToString()
+        Set-Location $env:temp
+        $tempDir = New-Item -Type Directory -Name $tempDirName
+        
+        Try
+        {
+            Set-Location $tempDir
+            Copy-Item -Path $config.SqlFile -Destination ([System.IO.Path]::Combine($tempDir.FullName, 'script.sql'))
+            
+            $tempDatabaseDir = New-Item -ItemType Directory -Name 'DATA'
+            ForEach ($extension in '*.mdf', '*.ldf')
+            {
+                Get-ChildItem -Path $config.DatabaseDir -Filter $extension | Copy-Item -Destination $tempDatabaseDir
+            }
+
+            $webClient = New-Object System.Net.WebClient
+            $webClient.DownloadFile('https://raw.githubusercontent.com/turboapps/turbome/master/sqlserver/content-layer/build.me', "$tempDir\build.me")
+
+            & "turbo.exe" build --overwrite --name $config.OutputImage build.me script.sql DATA
+        }
+        Finally
+        {
+            Set-Location $env:temp
+            Remove-Item -Recurse $tempDirName
+        }
+    }
+    Finally
+    {
+        Set-Location $initialLocation
+    }
+}
+
+$sqlFileExists = Test-Path $SqlFile
+if(-not $sqlFileExists)
+{
+    PrintFatal "Script file '$SqlFile' was not found"
+    Exit -1
+}
+
+$databaseDirExists = Test-Path $DatabaseDir
+if(-not $databaseDirExists)
+{
+    PrintFatal "Database directory '$DatabaseDir' was not found"
+    Exit -1
+}
+
+$config = New-Object -TypeName PsObject -Property (@{
+    'OutputImage' = $OutputImage;
+    'SqlFile' = (Get-Item $SqlFile | % { $_.FullName });
+    'DatabaseDir'= (Get-Item $DatabaseDir | % { $_.FullName });
+})  
+
+Try
+{
+    Build $config
+}
+Catch
+{
+    PrintFatal $_.Exception.Message
+    PrintFatal $_.Exception.StackTrace
+    Exit -1
+}

--- a/sqlserver/content-layer/content_layer.ps1
+++ b/sqlserver/content-layer/content_layer.ps1
@@ -1,4 +1,89 @@
-﻿[CmdletBinding()]
+﻿# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+<#
+
+.SYNOPSIS
+
+Script builds content layer images for SQL Server 2014 Lab Suite.
+
+
+.DESCRIPTION
+
+Script uses Turbo CLI to build a content layer image for SQL Server 2014 Lab Suite.
+
+Script requires providing paths to a SQL file and a directory with a detached database.
+
+After successful build the script will execute a test run using a temporary container and push the content layer image to the Turbo Hub. Both actions require user confirmation which can be given in an interactive mode during script execution or specified using command line switches.
+
+
+.PARAMETER OutputImage 
+
+Name of the output image with content layer
+
+
+.PARAMETER SqlFile
+
+Path to the SQL script
+
+
+.PARAMETER DatabaseDir
+
+Path to the database directory
+
+
+.PARAMETER RemoteImage
+
+Name of the image with content layer in the Turbo Hub
+
+
+.PARAMETER ConfirmRun
+
+Confirm to execute a test run.
+
+
+.PARAMETER DeclineRun
+
+Decline to execute a test run.
+
+
+.PARAMETER ConfirmPush
+
+Confirm to push the content layer image.
+
+
+.PARAMETER DeclinePush
+
+Decline to push the content layer image.
+
+
+.EXAMPLE
+
+.\content_layer.ps1
+
+
+Build an image with content layer in fully interactive mode. PowerShell script will ask to specify each required parameter. After successful build script will stop and ask for permissions to execute a test run and push the image.
+
+
+.EXAMPLE 
+
+.\content_layer.ps1 -SqlFile '..\samples\WildcardSearches\Wildcard Searches.sql' -DatabaseDir '..\samples\WildcardSearches\DATA' -OutputImage 'demo-content' -DeclineRun -ConfirmPush -RemoteImage 'sqlservercentral/wildcard-searches'
+
+Build a content layer image using 'Wildcard Searches.sql' script a sample database saved in 'DATA' directory. The output image will be saved in the local repository as 'demo-content'. After successful build PowerShell script will skip a test run and push the image to the Turbo Hub to 'wildcard-searches' repo in 'sqlservercentral' organization.
+
+
+.NOTES
+
+Script requires access to the Internet to download a TurboScript, pull mssql2014-labsuite image with SQL Server 2014 Lab Suite and push a content layer image to the Turbo Hub.
+Script invokes Turbo Plugin CLI commands, so Turbo Plugin must be installed on the host machine. The latest Turbo Plugin release can be downloaded from http://start.turbo.net/install.
+Script is compatible with PowerShell 2.0 and is not calling .Net API above .Net Framework 2.0.
+
+.Link
+
+https://github.com/turboapps/turbome/blob/sqlserver/powershell/sqlserver/README.md
+
+#>
+[CmdletBinding()]
 param
 (
 	[Parameter(Mandatory=$True,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,HelpMessage="Name of the output image")]


### PR DESCRIPTION
SYNOPSIS
Script builds content layer images for SQL Server 2014 Lab Suite.
    
SYNTAX
C:\s\turbome\sqlserver\content-layer\Build-ContentLayer.ps1 [-OutputImage String] [-SqlFile String] [-DatabaseDir String] [-ConfirmRun] [-DeclineRun] [-ConfirmPush] [-DeclinePush] [-RemoteImage String]

Script uses Turbo CLI to build a content layer image for SQL Server 2014 Lab Suite.
    
Script requires providing paths to a SQL file and a directory with a detached database.
    
After successful build the script will execute a test run using a temporary container and push the content layer image to the Turbo Hub. Both actions require user confirmation which can be given in an interactive mode during script execution or specified using command line switches.
    
```
C:\PS>.\Build-ContentLayer.ps1
```
Build an image with content layer in fully interactive mode. PowerShell script will ask to specify each required parameter. After successful build script will stop and ask for permissions to execute a test run and push the image.

```
C:\PS>.\Build-ContentLayer.ps1 -SqlFile '..\samples\WildcardSearches\Wildcard Searches.sql' -DatabaseDir '..\samples\WildcardSearches\DATA' -OutputImage 'demo-content' -DeclineRun -ConfirmPush -RemoteImage  'sqlservercentral/wildcard-searches'
```
Build a content layer image using 'Wildcard Searches.sql' script a sample database saved in 'DATA' directory. The output image will be saved in the local repository as 'demo-content'. After successful build PowerShell script will skip a test run and push the image to the Turbo Hub to 'wildcard-searches' repo in 'sqlservercentral' organization.