### PR TITLE
APPQ-1957

### DIFF
--- a/klondike/turbo.me
+++ b/klondike/turbo.me
@@ -1,0 +1,84 @@
+#
+# Klondike turbo.me file
+# https://github.com/turboapps/turbome/tree/master/klondike]
+#
+# Created with Turbo CMD version 1.4.2242.0
+#
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+###################################
+# Meta tags
+###################################
+
+meta title="Klondike"
+meta namespace="klondike"
+meta name="klondike"
+
+
+###################################
+# Pull dependency images
+###################################
+
+using turbo/turboscript-tools:2016.1.27
+
+
+###################################
+# Download and install
+###################################
+
+# Set working directory
+cmd mkdir c:\Workspace
+workdir c:\Workspace
+
+# Get download link and version
+batch cmd
+    echo import requests >> getDownloadLink.py
+    echo import re >> getDownloadLink.py
+    echo headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:41.0) Gecko/20100101 Firefox/41.0'} >> getDownloadLink.py
+    echo release = requests.get('https://api.github.com/repos/themotleyfool/Klondike/releases/latest' , headers=headers, timeout=10).json() >> getDownloadLink.py
+    echo tag_name = release['tag_name'][1:] >> getDownloadLink.py
+    echo download_url = release['assets'][0]['browser_download_url'] >> getDownloadLink.py
+    echo print([download_url,tag_name]) >> getDownloadLink.py
+
+cmd python getDownloadLink.py
+var res = last
+
+cmd "python -c ""print(%res%[0])"""
+var url = last
+
+cmd "python -c ""print(%res%[1])"""
+var version = last
+    
+# Download and unpack
+batch cmd
+    wget --no-verbose --no-check-certificate -O klondike.zip %url%
+    mkdir c:\Klondike
+    7z x klondike.zip -oc:\Klondike > nul
+
+
+###################################
+# Clean up
+###################################
+
+cmd copy c:\TurboBuildTools\PowerShell\Turbo c:\Workspace
+cmd powershell -command ". .\Remove-BuildTools.ps1; Remove-BuildTools"
+
+workdir c:\
+cmd rmdir c:\Workspace /s /q
+cmd rmdir c:\TurboBuildTools /s /q
+
+
+###################################
+# Version
+###################################
+
+meta tag=version
+
+
+###################################
+# Startup File
+###################################
+
+startup file ("c:\Klondike\bin\Klondike.SelfHost.exe")
+


### PR DESCRIPTION
##### Add Nuget.Server to CI
* Added TurboScript for [Klondike](https://github.com/themotleyfool/Klondike) an open source self-hosted Nuget package feed
* Traditional Nuget.Server is distributed as a Nuget package hosted on IIS
   * IIS image is not available in the hub
   * have not found an easy way to make Nuget.Server self-hosted using [OWIN](http://owin.org/) 
