### PR TITLE
APPQ-1996

### DIFF
--- a/libreoffice/base/turbo.me
+++ b/libreoffice/base/turbo.me
@@ -51,6 +51,11 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/APPQ-1996/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
+
 ###################################
 # Startup File
 ###################################

--- a/libreoffice/calc/turbo.me
+++ b/libreoffice/calc/turbo.me
@@ -50,6 +50,10 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/master/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
 ###################################
 # Startup File
 ###################################

--- a/libreoffice/draw/turbo.me
+++ b/libreoffice/draw/turbo.me
@@ -50,6 +50,10 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/master/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
 ###################################
 # Startup File
 ###################################

--- a/libreoffice/full/turbo.me
+++ b/libreoffice/full/turbo.me
@@ -51,6 +51,10 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/master/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
 ###################################
 # Startup File
 ###################################

--- a/libreoffice/impress/turbo.me
+++ b/libreoffice/impress/turbo.me
@@ -50,6 +50,10 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/master/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
 ###################################
 # Startup File
 ###################################

--- a/libreoffice/math/turbo.me
+++ b/libreoffice/math/turbo.me
@@ -50,6 +50,10 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/master/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
 ###################################
 # Startup File
 ###################################

--- a/libreoffice/shared/turnoff-opengl.reg
+++ b/libreoffice/shared/turnoff-opengl.reg
@@ -1,0 +1,15 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Policies\LibreOffice]
+
+[HKEY_CURRENT_USER\Software\Policies\LibreOffice\org.openoffice.Office.Common]
+
+[HKEY_CURRENT_USER\Software\Policies\LibreOffice\org.openoffice.Office.Common\VCL]
+
+[HKEY_CURRENT_USER\Software\Policies\LibreOffice\org.openoffice.Office.Common\VCL\ForceOpenGL]
+"Value"="false"
+"Final"=dword:00000001
+
+[HKEY_CURRENT_USER\Software\Policies\LibreOffice\org.openoffice.Office.Common\VCL\UseOpenGL]
+"Value"="false"
+"Final"=dword:00000001

--- a/libreoffice/writer/turbo.me
+++ b/libreoffice/writer/turbo.me
@@ -50,6 +50,10 @@ var tag=last
 # Actually install MSI
 cmd msiexec /i %url% /passive /qn
 
+# Turn off OpenGL
+cmd wget --no-check-certificate --quiet -O turnoff-opengl.reg https://raw.githubusercontent.com/turboapps/turbome/master/libreoffice/shared/turnoff-opengl.reg
+cmd regedit.exe /S turnoff-opengl.reg
+
 ###################################
 # Startup File
 ###################################


### PR DESCRIPTION
##### Fixed libreoffice 5.1.0 crashes on start
* Libre Office 5.1.0 launches with OpenGL without checking if it is supported. It causes an application to crash when running on a VM.