### PR TITLE
APPQ-1999

### DIFF
--- a/dotnet/cli/turbo.me
+++ b/dotnet/cli/turbo.me
@@ -1,0 +1,72 @@
+#
+# .NET Command Line Tools turbo.me file
+# https://github.com/turboapps/turbome/tree/master/dotnet/cli]
+#
+# Created with Turbo CMD version 1.4.1085.0
+#
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+###################################
+# Meta tags
+###################################
+
+meta title=".NET Command Line Tools"
+meta namespace="microsoft"
+meta name="dotnet-cli"
+
+###################################
+# Pull dependency images
+###################################
+
+using turbo/turboscript-tools:2016.2.4
+
+
+###################################
+# Download and install
+###################################
+
+# Set working directory
+cmd mkdir c:\Workspace
+workdir c:\Workspace
+
+cmd wget --no-check-certificate -O installer.exe https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x64.latest.exe
+cmd installer.exe /silent
+
+# Get product version
+cmd copy c:\TurboBuildTools\PowerShell\Turbo c:\Workspace
+cmd powershell -command ". .\Get-FileVersion.ps1; Get-FileVersion -Path installer.exe" > image.txt
+cmd findstr "." image.txt
+var version = last
+
+###################################
+# Environment Variables
+###################################
+
+env path="@ProgramFiles@\dotnet\bin"
+
+
+###################################
+# Clean up
+###################################
+
+cmd powershell -command ". .\Remove-BuildTools.ps1; Remove-BuildTools"
+
+workdir c:\
+
+cmd rmdir c:\Workspace /s /q
+cmd rmdir c:\TurboBuildTools /s /q
+
+
+###################################
+# Version
+###################################
+
+meta tag=version
+
+
+###################################
+# Startup File
+###################################
+
+startup file ("cmd","/k echo .NET Command Line Tools version: ", version)

--- a/dotnet/core-clr/x64/turbo.me
+++ b/dotnet/core-clr/x64/turbo.me
@@ -1,0 +1,61 @@
+#
+# .NET Core CLR x64 turbo.me file
+# https://github.com/turboapps/turbome/tree/master/dotnet/core-clr/x64
+#
+# Created with Turbo CMD version 1.4.1085.0
+#
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+###################################
+# Meta tags
+###################################
+
+meta title=".NET Core CLR x64"
+meta namespace="microsoft"
+meta name="core-clr-x64"
+
+
+###################################
+# Download and install
+###################################
+
+# Set working directory
+cmd mkdir c:\Workspace
+workdir c:\Workspace
+
+# Install DNVM tool
+cmd powershell -NoProfile -ExecutionPolicy unrestricted -Command "&{$Branch='dev';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.ps1'))}"
+
+# Install Core CLR
+cmd dnvm install -Runtime coreclr latest -Architecture x64 -Unstable -Persistent
+
+# Get product version
+cmd dnvm list > version.data
+cmd powershell -command "(Get-Content version.data) | Select-String -Pattern \d[^\s]+ | ForEach-Object {$_.Matches.value}  | Select -First 1"
+var version=last
+
+
+###################################
+# Clean up
+###################################
+
+workdir c:\
+
+cmd rmdir c:\Workspace /s /q
+
+
+###################################
+# Version
+###################################
+
+meta tag=version
+
+
+###################################
+# Startup File
+###################################
+
+
+startup file ("cmd", "/k echo .NET Core CLR x64 version: ", version)
+

--- a/dotnet/core-clr/x86/turbo.me
+++ b/dotnet/core-clr/x86/turbo.me
@@ -1,0 +1,61 @@
+#
+# .NET Core CLR x86 turbo.me file
+# https://github.com/turboapps/turbome/tree/master/dotnet/core-clr/x86
+#
+# Created with Turbo CMD version 1.4.1085.0
+#
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+###################################
+# Meta tags
+###################################
+
+meta title=".NET Core CLR x86"
+meta namespace="microsoft"
+meta name="core-clr-x86"
+
+
+###################################
+# Download and install
+###################################
+
+# Set working directory
+cmd mkdir c:\Workspace
+workdir c:\Workspace
+
+# Install DNVM tool
+cmd powershell -NoProfile -ExecutionPolicy unrestricted -Command "&{$Branch='dev';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.ps1'))}"
+
+# Install Core CLR
+cmd dnvm install -Runtime coreclr latest -Architecture x86 -Unstable -Persistent
+
+# Get product version
+cmd dnvm list > version.data
+cmd powershell -command "(Get-Content version.data) | Select-String -Pattern \d[^\s]+ | ForEach-Object {$_.Matches.value}  | Select -First 1"
+var version=last
+
+
+###################################
+# Clean up
+###################################
+
+workdir c:\
+
+cmd rmdir c:\Workspace /s /q
+
+
+###################################
+# Version
+###################################
+
+meta tag=version
+
+
+###################################
+# Startup File
+###################################
+
+
+startup file ("cmd", "/k echo .NET Core CLR x86 version: ", version)
+


### PR DESCRIPTION
##### Add .NET Core to CI

.NET Core is distributed as a .NET Execution Environment (DNX) and with .NET Command Line Tools.

The pull requests contains TurboScripts for the following distributions:

Namespace | Repo name | Friendly name | Comment
------------ | ------------ | ------------- | ------------- 
microsoft | core-clr-x86 | .NET Core CLR x86 | .NET Execution Environment (DNX), installed using DNVM
microsoft | core-clr-x64 | .NET Core CLR x64 | .NET Execution Environment (DNX), installed using DNVM
microsoft | dotnet-cli | .NET Command Line Tools | Downloaded from https://dotnet.github.io/, only x64 installer is available

Please let me leave a comment if basic repo metadata (repo name, friendly name) should be changed. Going to merge it tomorrow.
 