### PR TITLE
Use more reasonable xappl syntax for window isolation settings

### DIFF
--- a/google/chrome/Resources/post_snapshot.ps1
+++ b/google/chrome/Resources/post_snapshot.ps1
@@ -36,7 +36,7 @@ Remove-RegistryItems $xappl "@HKCU@\Software\Microsoft"
 Remove-RegistryItems $xappl "@HKLM@\SOFTWARE\Wow6432Node\Microsoft"
 Remove-RegistryItems $xappl "@HKLM@\SOFTWARE\Microsoft"
 
-Add-ObjectMap $xappl -Name 'window://Chrome_MessageWindow:Chrome_MessageWindow'
+Add-ObjectMap $xappl -Name 'window://Chrome_MessageWindow:0'
 
 Disable-Services $xappl 
 

--- a/turbobrowsers/turbobase/post_snapshot.ps1
+++ b/turbobrowsers/turbobase/post_snapshot.ps1
@@ -31,6 +31,6 @@ Set-RegistryIsolation $xappl '@HKLM@\SOFTWARE\Microsoft\Windows' $FullIsolation
 
 Set-RegistryValue $xappl -Path '@HKLM@\SOFTWARE\Wow6432Node\Mozilla\Firefox\TaskBarIDs' -Key '@PROGRAMFILESX86@\Mozilla Firefox' -Value ''
 
-Add-ObjectMap $xappl -Name 'Window://firefoxMessageWindow:firefoxMessageWindow'
+Add-ObjectMap $xappl -Name 'Window://firefoxMessageWindow:0'
 
 Save-XAPPL $xappl $XappPath

--- a/turbobrowsers/webexmeetingcenter/postsnapshot.ps1
+++ b/turbobrowsers/webexmeetingcenter/postsnapshot.ps1
@@ -38,6 +38,6 @@ Add-StartupFile $xappl -File $firefoxExe -CommandLine 'https://signin.webex.com/
 Add-StartupFile $xappl -File $firefoxExe -CommandLine 'https://signin.webex.com/collabs/#/meetings/joinbynumber' -Name 'join'
 Add-StartupFile $xappl -File $firefoxExe -CommandLine 'https://signin.webex.com/collabs/auth?service=it&from=hostmeeting' -Name 'host'
 
-Add-ObjectMap $xappl -Name 'Window://firefoxMessageWindow:firefoxMessageWindow'
+Add-ObjectMap $xappl -Name 'Window://firefoxMessageWindow:0'
 
 Save-XAPPL $xappl $XappPath


### PR DESCRIPTION
See commit 6017a9d5d384419fc21bc143a575311d5efff073 in cmd for the same
change in turbo.exe-produced images.

Currently both syntaxes have exactly the same effect in VM. However, the
one proposed here is more forward-compatible.