### PR TITLE
WEB-5773: end to end cache management: Enable Chrome sync. 

### DIFF
--- a/chromium/canary/post_snapshot.ps1
+++ b/chromium/canary/post_snapshot.ps1
@@ -25,6 +25,10 @@ Remove-RegistryItems $xappl "@HKCU@\Software\Microsoft"
 Remove-RegistryItems $xappl "@HKLM@\SOFTWARE\Wow6432Node\Microsoft"
 Remove-RegistryItems $xappl "@HKLM@\SOFTWARE\Microsoft"
 
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Chromium" $true
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Chromium\User Data\Default\Cache" $false
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Chromium\User Data\ShaderCache" $false
+
 Remove-StartupFiles $xappl
 Add-StartupFile $xappl -File "@SYSDRIVE@\Chromium\chrome-win32\chrome.exe" -AutoStart
 

--- a/google/chrome/Resources/post_snapshot.ps1
+++ b/google/chrome/Resources/post_snapshot.ps1
@@ -29,7 +29,7 @@ Set-FileSystemIsolation $xappl "@PROGRAMFILESX86@\Google" $FullIsolation
 
 
 # Enable sync for the profile, while disable sync for the caches
-Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google" $true
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google\Chrome" $true
 Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google\Chrome\User Data\Default\Cache" $false
 Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google\Chrome\User Data\ShaderCache" $false
 

--- a/google/chrome/Resources/post_snapshot.ps1
+++ b/google/chrome/Resources/post_snapshot.ps1
@@ -27,6 +27,12 @@ Set-FileSystemIsolation $xappl "@APPDATACOMMON@\Microsoft" $FullIsolation
 Set-FileSystemIsolation $xappl "@APPDATALOCAL@\Google" $FullIsolation
 Set-FileSystemIsolation $xappl "@PROGRAMFILESX86@\Google" $FullIsolation
 
+
+# Enable sync for the profile, while disable sync for the caches
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google" $true
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google\Chrome\User Data\Default\Cache" $false
+Set-FileEnableSystemSync $xappl "@APPDATALOCAL@\Google\Chrome\User Data\ShaderCache" $false
+
 Remove-FileSystemDirectoryItems $xappl "@SYSDRIVE@"
 
 Set-RegistryIsolation $xappl "@HKCU@\Software\Google" $FullIsolation
@@ -42,3 +48,4 @@ Remove-Service $xappl 'gupdate'
 Remove-Service $xappl 'gupdatem'
 
 Save-XAPPL $xappl $XappPath
+Get-Content $XappPath

--- a/google/chrome/stable/de-de/turbo.me
+++ b/google/chrome/stable/de-de/turbo.me
@@ -58,6 +58,13 @@ cmd rmdir c:\Workspace /s /q
 cmd rmdir c:\wget /s /q
 
 ###################################
+# Enable sync for base directory
+###################################
+sync enable "@APPDATALOCAL@\Google\Chrome\"
+sync disable "@APPDATALOCAL@\Google\Chrome\User Data\Default\Cache"
+sync disable "@APPDATALOCAL@\User Data\ShaderCache"
+
+###################################
 # Version
 ###################################
 

--- a/google/chrome/stable/es-es/turbo.me
+++ b/google/chrome/stable/es-es/turbo.me
@@ -58,6 +58,13 @@ cmd rmdir c:\Workspace /s /q
 cmd rmdir c:\wget /s /q
 
 ###################################
+# Enable sync for base directory
+###################################
+sync enable "@APPDATALOCAL@\Google\Chrome\"
+sync disable "@APPDATALOCAL@\Google\Chrome\User Data\Default\Cache"
+sync disable "@APPDATALOCAL@\User Data\ShaderCache"
+
+###################################
 # Version
 ###################################
 

--- a/google/chrome/stable/fr-fr/turbo.me
+++ b/google/chrome/stable/fr-fr/turbo.me
@@ -58,6 +58,13 @@ cmd rmdir c:\Workspace /s /q
 cmd rmdir c:\wget /s /q
 
 ###################################
+# Enable sync for base directory
+###################################
+sync enable "@APPDATALOCAL@\Google\Chrome\"
+sync disable "@APPDATALOCAL@\Google\Chrome\User Data\Default\Cache"
+sync disable "@APPDATALOCAL@\User Data\ShaderCache"
+
+###################################
 # Version
 ###################################
 

--- a/tools/powershell/Turbo/XAPPL.ps1
+++ b/tools/powershell/Turbo/XAPPL.ps1
@@ -104,6 +104,15 @@ function Set-FileSystemIsolation($xappl, $path, $isolationMode)
     $xappl.SelectNodes($xpath) | ForEach-Object { $_.isolation = $isolationMode }
 }
 
+function Set-FileEnableSystemSync($xappl, $path, $sync)
+{
+    $xpath = Get-FileSystemXPath($path)+'//Directory'
+    # Consistant with turbo script, synching enables/disables for all children
+    $allSubDirsPath = $xpath+'//Directory'
+    $nodes = $xappl.SelectNodes($allSubDirsPath)
+    $nodes | ForEach-Object { $_.noSync = (!$sync).ToString() }
+}
+
 function Set-RegistryIsolation($xappl, $path, $isolationMode)
 {
     $xpath = Get-RegistryXPath($path)
@@ -720,6 +729,7 @@ Export-ModuleMember -Function 'Set-EnvironmentVariable'
 Export-ModuleMember -Function 'Set-FileSystemIsolation'
 Export-ModuleMember -Function 'Set-RegistryIsolation'
 Export-ModuleMember -Function 'Set-RegistryValue'
+Export-ModuleMember -Function 'Set-FileEnableSystemSync'
 
 Export-ModuleMember -Variable FullIsolation
 Export-ModuleMember -Variable MergeIsolation

--- a/tools/powershell/Turbo/XAPPL.ps1
+++ b/tools/powershell/Turbo/XAPPL.ps1
@@ -106,11 +106,13 @@ function Set-FileSystemIsolation($xappl, $path, $isolationMode)
 
 function Set-FileEnableSystemSync($xappl, $path, $sync)
 {
-    $xpath = Get-FileSystemXPath($path)+'//Directory'
     # Consistant with turbo script, synching enables/disables for all children
-    $allSubDirsPath = $xpath+'//Directory'
-    $nodes = $xappl.SelectNodes($allSubDirsPath)
-    $nodes | ForEach-Object { $_.noSync = (!$sync).ToString() }
+    $xpath = Get-FileSystemXPath($path)
+    $mainNode = $xappl.SelectNodes($xpath)
+    $mainNode | ForEach-Object { $_.noSync = (!$sync).ToString() }
+    $allSubDirsPath = $xpath + '//Directory'
+    $subDirs = $xappl.SelectNodes($allSubDirsPath)
+    $subDirs | ForEach-Object { $_.noSync = (!$sync).ToString() }
 }
 
 function Set-RegistryIsolation($xappl, $path, $isolationMode)


### PR DESCRIPTION
Fixes Chrome sync on config level, by enabling syncing it's directories.
Will also move the files when forking a image.

However: Syncing still won't work, due to: VM-1555 Chrome Sync sandbox does not work 