### PR TITLE
Adding scripts for Whisper

### DIFF
--- a/whisper/README.md
+++ b/whisper/README.md
@@ -1,0 +1,24 @@
+# Whisper
+
+Site: [OpenAI Whisper](https://openai.com/blog/whisper/)
+Source: [Github Repository](https://github.com/openai/whisper)
+
+## Build and Run Instructions
+
+To build the whisper runtime:
+`turbo build whisper-runtime/turbo.me`
+
+This will give you an image that is able to run whisper, but which does not have any models pre-installed. When you run a container using just a whisper-runtime image, it will download the model file it needs.
+
+To run a container using a whisper-runtime image:
+`turbo new whisper-runtime --mount=C:\path\to\audio -- TRANSCRIBE C:\path\to\audio\audio.wav C:\path\to\audio\transcription.txt`
+
+To build a whisper image that has the tiny model pre-installed, make sure you have either built or pulled a whisper-runtime image, then run:
+`turbo build whisper-tiny/turbo.me`
+
+To run a container using a whisper-tiny image:
+`turbo new whisper-tiny --mount=C:\path\to\audio -- TRANSCRIBE C:\path\to\audio\audio.wav C:\path\to\audio\transcription.txt`
+
+It is possible to use other models instead of the tiny model, however, this will require the `whisper_caller.py` file in the `resources` folder to be edited to refer to the desired model, and a new whisper-runtime image will need to be built.
+
+Pre-installing other whisper models onto an image built on top of whisper-runtime is also possible, refer to `whisper-tiny/turbo.me` to see how this can be achieved.

--- a/whisper/README.md
+++ b/whisper/README.md
@@ -6,7 +6,7 @@ Source: [Github Repository](https://github.com/openai/whisper)
 ## Build and Run Instructions
 
 To build the whisper runtime:
-`turbo build whisper-runtime/turbo.me`
+`turbo build whisper-runtime\turbo.me`
 
 This will give you an image that is able to run whisper, but which does not have any models pre-installed. When you run a container using just a whisper-runtime image, it will download the model file it needs.
 
@@ -14,7 +14,7 @@ To run a container using a whisper-runtime image:
 `turbo new whisper-runtime --mount=C:\path\to\audio -- TRANSCRIBE C:\path\to\audio\audio.wav C:\path\to\audio\transcription.txt`
 
 To build a whisper image that has the tiny model pre-installed, make sure you have either built or pulled a whisper-runtime image, then run:
-`turbo build whisper-tiny/turbo.me`
+`turbo build whisper-tiny\turbo.me`
 
 To run a container using a whisper-tiny image:
 `turbo new whisper-tiny --mount=C:\path\to\audio -- TRANSCRIBE C:\path\to\audio\audio.wav C:\path\to\audio\transcription.txt`

--- a/whisper/resources/main.py
+++ b/whisper/resources/main.py
@@ -1,0 +1,25 @@
+import sys
+import whisper_caller
+
+def main():
+    if len(sys.argv) > 1:
+        skill = sys.argv[1]
+    else:
+        print ("Invalid number of arguments. Expected usage: <skill> [<skill_args>...]")
+        return -1
+
+    if skill.upper() == "TRANSCRIBE":
+        if len(sys.argv) > 3:
+            inputFile = sys.argv[2]
+            outputFile = sys.argv[3]
+        else:
+            print ("Invalid number of arguments. Expected usage: TRANSCRIBE <inputFile> <outputFile>")
+            return -1
+
+        whisper_caller.transcribe(inputFile, outputFile)
+    else:
+        print("Invalid skill name")
+        return -1
+
+if __name__ == "__main__":
+    main()

--- a/whisper/resources/whisper_caller.py
+++ b/whisper/resources/whisper_caller.py
@@ -1,0 +1,26 @@
+import whisper
+import sys
+
+def transcribe(audioFile, outputFile):
+    model = whisper.load_model("tiny")
+
+    # load audio and pad/trim it to fit 30 seconds
+    audio = whisper.load_audio(audioFile)
+    audio = whisper.pad_or_trim(audio)
+
+    # make log-Mel spectrogram and move to the same device as the model
+    mel = whisper.log_mel_spectrogram(audio).to(model.device)
+
+    # detect the spoken language
+    _, probs = model.detect_language(mel)
+    print(f"Detected language: {max(probs, key=probs.get)}")
+
+    # decode the audio
+    options = whisper.DecodingOptions(fp16 = False)
+    result = whisper.decode(model, mel, options)
+
+    # print the recognized text
+    print(result.text)
+
+    with open(outputFile, 'w') as f:
+        f.write(result.text)

--- a/whisper/whisper-runtime/turbo.me
+++ b/whisper/whisper-runtime/turbo.me
@@ -34,6 +34,12 @@ cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\main.py 
 cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\whisper_caller.py https://raw.githubusercontent.com/turboapps/turbome/master/whisper/resources/whisper_caller.py
 
 ###################################
+# Environment Variables
+###################################
+
+env path="@SYSDRIVE@\ffmpeg"
+
+###################################
 # Startup File
 ###################################
 

--- a/whisper/whisper-runtime/turbo.me
+++ b/whisper/whisper-runtime/turbo.me
@@ -1,0 +1,40 @@
+# Whisper runtime turbo.me file
+#
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+###################################
+# Meta tags
+###################################
+
+meta title="whisper-runtime"
+meta namespace="whisper-runtime"
+meta name="whisper-runtime"
+
+###################################
+# Pull dependency images
+###################################
+
+using wget:1.18,git
+
+layer python:3.9.6,ffmpeg
+
+###################################
+# Download and install
+###################################
+
+batch cmd
+ pip install torch
+ pip install transformers
+ pip install ffmpeg-python
+ pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
+
+cmd mkdir @APPDATACOMMON@\Whisper\
+cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\main.py https://raw.githubusercontent.com/turboapps/turbome/master/whisper/resources/main.py
+cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\whisper_caller.py https://raw.githubusercontent.com/turboapps/turbome/master/whisper/resources/whisper_caller.py
+
+###################################
+# Startup File
+###################################
+
+startup file @APPDATACOMMON@\Whisper\main.py

--- a/whisper/whisper-runtime/turbo.me
+++ b/whisper/whisper-runtime/turbo.me
@@ -8,7 +8,7 @@
 ###################################
 
 meta title="whisper-runtime"
-meta namespace="whisper-runtime"
+meta namespace="openai"
 meta name="whisper-runtime"
 
 ###################################
@@ -33,11 +33,24 @@ cmd mkdir @APPDATACOMMON@\Whisper\
 cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\main.py https://raw.githubusercontent.com/turboapps/turbome/master/whisper/resources/main.py
 cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\whisper_caller.py https://raw.githubusercontent.com/turboapps/turbome/master/whisper/resources/whisper_caller.py
 
+# Batch script for making sure files are not empty
+cmd echo @echo off > checkZeroBytes.bat
+cmd echo if %~z1 lss 1 echo ERROR: %~n1 is 0 bytes >> checkZeroBytes.bat
+
+cmd checkZeroBytes.bat @APPDATACOMMON@\Whisper\main.py
+cmd checkZeroBytes.bat @APPDATACOMMON@\Whisper\whisper_caller.py
+
 ###################################
 # Environment Variables
 ###################################
 
 env path="@SYSDRIVE@\ffmpeg"
+
+###################################
+# Clean up
+###################################
+
+cmd del checkZeroBytes.bat
 
 ###################################
 # Startup File

--- a/whisper/whisper-tiny/turbo.me
+++ b/whisper/whisper-tiny/turbo.me
@@ -8,7 +8,7 @@
 ###################################
 
 meta title="whisper-tiny"
-meta namespace="whisper-tiny"
+meta namespace="openai"
 meta name="whisper-tiny"
 
 ###################################

--- a/whisper/whisper-tiny/turbo.me
+++ b/whisper/whisper-tiny/turbo.me
@@ -1,0 +1,39 @@
+# Whisper tiny turbo.me file
+#
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+###################################
+# Meta tags
+###################################
+
+meta title="whisper-tiny"
+meta namespace="whisper-tiny"
+meta name="whisper-tiny"
+
+###################################
+# Pull dependency images
+###################################
+
+layer whisper-runtime
+
+###################################
+# Download and install
+###################################
+
+# Script to pre-install model
+batch
+ echo import sys > getModel.py
+ echo import os >> getModel.py
+ echo from whisper import _download, _MODELS >> getModel.py
+ echo download_root = os.path.join(os.getenv("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")), "whisper") >> getModel.py
+ echo _download(_MODELS["tiny"], download_root, False) >> getModel.py
+
+# Pre-install model so it doesn't get downloaded on container startup
+cmd python getModel.py
+
+###################################
+# Clean up
+###################################
+
+cmd del getModel.py


### PR DESCRIPTION
Adding turbo.me scripts for whisper images, as well as the python scripts needed for the images and instructions on how to build and run whisper.

Currently, the links that are being wget in whisper/whisper-runtime/turbo.me to main.py and whisper_caller.py do not exist; these will exist once merged into master but right now these github gist links will work if substituted:
https://gist.githubusercontent.com/ncaracelo1/31416fcae28fde9c27120378d68ede59/raw/49b73281941e07c23d6c6b9e0a6b65d78610e8a8/main.py
https://gist.githubusercontent.com/ncaracelo1/31416fcae28fde9c27120378d68ede59/raw/49b73281941e07c23d6c6b9e0a6b65d78610e8a8/whisper_caller.py