### PR TITLE
Whisper image only transcribed the first 30 seconds of audio

### DIFF
--- a/whisper/resources/whisper_caller.py
+++ b/whisper/resources/whisper_caller.py
@@ -1,26 +1,11 @@
 import whisper
-import sys
 
 def transcribe(audioFile, outputFile):
     model = whisper.load_model("tiny")
-
-    # load audio and pad/trim it to fit 30 seconds
-    audio = whisper.load_audio(audioFile)
-    audio = whisper.pad_or_trim(audio)
-
-    # make log-Mel spectrogram and move to the same device as the model
-    mel = whisper.log_mel_spectrogram(audio).to(model.device)
-
-    # detect the spoken language
-    _, probs = model.detect_language(mel)
-    print(f"Detected language: {max(probs, key=probs.get)}")
-
-    # decode the audio
-    options = whisper.DecodingOptions(fp16 = False)
-    result = whisper.decode(model, mel, options)
+    result = model.transcribe(audioFile)
 
     # print the recognized text
-    print(result.text)
+    print(result["text"])
 
     with open(outputFile, 'w') as f:
-        f.write(result.text)
+        f.write(result["text"])

--- a/whisper/whisper-runtime/turbo.me
+++ b/whisper/whisper-runtime/turbo.me
@@ -27,6 +27,7 @@ batch cmd
  pip install torch
  pip install transformers
  pip install ffmpeg-python
+ pip install numba
  pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
 
 cmd mkdir @APPDATACOMMON@\Whisper\


### PR DESCRIPTION
The OpenAI Whisper sample script used previously only transcribed the first 30 second window from the audio file, failing to fully transcribe audio files longer than 30s. This update follows the sample script from the openai whisper github repo to read the entire file and processes the audio with a sliding 30-second window. See https://github.com/openai/whisper#python-usage

For testing purposes, you may replace the following line:
`cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\whisper_caller.py https://raw.githubusercontent.com/turboapps/turbome/master/whisper/resources/whisper_caller.py`
with:
`cmd wget --no-check-certificate --no-verbose -O @APPDATACOMMON@\Whisper\whisper_caller.py https://gist.githubusercontent.com/michaelrush/b1d6dee20306bc0a93f1633355893404/raw/3f1c5e77225396e3f9a48cca431b44b98dc494c1/whisper_caller.py`