### PR TITLE
Upgrade turboscript-tools python dependency to latest version

### DIFF
--- a/tools/turbo.me
+++ b/tools/turbo.me
@@ -21,10 +21,13 @@ meta name="turboscript-tools"
 ###################################
 
 layer chocolatey/chocolatey:0.9.9.11
-layer python/python:3.4.4
+layer python/python:3.9.6
 layer wget
 layer 7-zip/7-zip
 
+# The chocolately and wget images mistakenly set the PYTHONHOME environmental variable to value that is not supported by the Python 3.9.6 image.
+# This results in pip install commands to fail. Unset the variable here, as the Python 3.9.6 image expects it to be unset
+env PYTHONHOME=
 
 ###################################
 # Download and install


### PR DESCRIPTION
This PR upgrades the turboscript-tools image from Python 3.4.4 to 3.9.6, which is required for the Portal build script to compile certain native packages with node-gyp when running npm install.

As part of this change I found that the chocolatey and wget images incorrect set the PYTHONHOME environmental variable to `C:\Python34` which is specific to Python 3.4 and not supported by Python 3.9 and causes the pip install commands to fail.

This will resolve the following node build error:
https://github.com/codesystems/portal/actions/runs/4747581454/jobs/8432671739
```
gyp ERR! find Python - executable path is "C:\Python34\python.exe"
gyp ERR! find Python - version is "3.4.4"
gyp ERR! find Python - version is 3.4.4 - should be ^2.6.0 || >=3.5.0
gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
```