### PR TITLE
Fix vlc build

### DIFF
--- a/vlc/stable/turbo.me
+++ b/vlc/stable/turbo.me
@@ -19,8 +19,7 @@ meta name="vlc"
 # Pull dependency images
 ###################################
 
-using gnu/wget,python/python:3.4.1
-# Doesn't work with python 3.4.3
+using gnu/wget,python/python:3.9.6
 
 
 ###################################
@@ -34,6 +33,7 @@ workdir c:\Workspace
 
 # Get URL from web
 cmd pip install requests --quiet
+cmd pip install chardet --quiet
 
 batch 
   echo import requests >> getUrl.py 
@@ -82,7 +82,7 @@ workdir c:\
 
 cmd rmdir c:\Workspace /s /q
 cmd rmdir C:\wget /s /q
-cmd rmdir C:\python34 /s /q
+cmd rmdir C:\python3 /s /q
 
 ###################################
 # Version


### PR DESCRIPTION
- update to use python 3.9.6 dependency due to pip install requests failing
- Add required chardet module